### PR TITLE
FIX do_fam10h_workaround_420

### DIFF
--- a/driver/ibs-interrupt.c
+++ b/driver/ibs-interrupt.c
@@ -159,6 +159,7 @@ static inline void handle_ibs_op_event(struct pt_regs *regs)
 	struct ibs_op *sample;
 	u64 tmp;
 
+	/* See do_fam10h_workaround_420() definition for details */
 	rdmsrl(MSR_IBS_OP_CTL, tmp);
 	if (!dev->workaround_fam10h_err_420 && !(tmp & IBS_OP_MAX_CNT_OLD))
 		return;
@@ -170,6 +171,9 @@ static inline void handle_ibs_op_event(struct pt_regs *regs)
 	sample = (struct ibs_op *)(dev->buf + (old_wr * dev->entry_size));
 
 	collect_op_data(dev, sample);
+	
+	/* Logically this is part of collect_common_data. However we can save
+	 * a MSR access beacause we already read the MSr_ibs_op_ctl */
 	sample->op_ctl = tmp;
 	collect_common_data(sample);
 

--- a/driver/ibs-workarounds.c
+++ b/driver/ibs-workarounds.c
@@ -357,6 +357,6 @@ void do_fam10h_workaround_420(const int cpu)
 {
 	__u64 old_op_ctl;
 	rdmsrl(MSR_IBS_OP_CTL, old_op_ctl);
-	old_op_ctl &= (~ IBS_OP_MAX_CNT_OLD);
+	old_op_ctl = (old_op_ctl | IBS_OP_VAL) & (~ IBS_OP_MAX_CNT_OLD);
 	custom_wrmsrl_on_cpu(cpu, MSR_IBS_OP_CTL, old_op_ctl);
 }

--- a/driver/ibs-workarounds.c
+++ b/driver/ibs-workarounds.c
@@ -357,6 +357,21 @@ void do_fam10h_workaround_420(const int cpu)
 {
 	__u64 old_op_ctl;
 	rdmsrl(MSR_IBS_OP_CTL, old_op_ctl);
+	
+	/* Within the two writes provided by the workaround an interrupt may
+	 * occur, but the driver could not understand it is intended
+	 * for ibs and leaves it unhandled. This would result in an unknown NMI.
+	 * Mostly this is not a problem, but in some systems, there may
+	 * be some mechanism such as the NMI watchdog which catches the interrupt 
+	 * and does operations (even system reboot) thinking it is due to 
+	 * an unexpected hardware behaviour. 
+	 * To tackle such a problem, we set the IBS_OP_VAL bit so that, if
+	 * an interrupt is generated because of the first write the driver can catch
+	 * it. The driver gets this is a workaround side effect when looking at the 
+	 * IBS_OP_CTL and sees the IBS_OP_VAL bit set and the IBS_OP_MAX_CNT(_OLD)
+	 * is equal to 0. In that case, the driver informs the system the interrupt
+	 * has been handled, but it doesn't restart the ibs logic. The last write
+	 * resets the IBS_OP_CTL. */  
 	old_op_ctl = (old_op_ctl | IBS_OP_VAL) & (~ IBS_OP_MAX_CNT_OLD);
 	custom_wrmsrl_on_cpu(cpu, MSR_IBS_OP_CTL, old_op_ctl);
 }

--- a/tools/ibs_decoder/ibs_decoder.c
+++ b/tools/ibs_decoder/ibs_decoder.c
@@ -119,8 +119,8 @@ void parse_args(int argc, char *argv[])
     char c;
     while ((c = getopt_long(argc, argv, "+hi:o:f:g:", longopts, NULL)) != -1)
     {
+        fprintf(stderr, "Found: %s : %c\n", argv[optind], c);
         switch (c) {
-            fprintf(stderr, "Found: %s : %c\n", argv[optind], c);
             case 'h':
             case '?':
                 fprintf(stderr, "This program parses IBS traces from the AMD Research IBS monitor.\n");

--- a/tools/ibs_monitor/ibs_monitor.c
+++ b/tools/ibs_monitor/ibs_monitor.c
@@ -516,7 +516,7 @@ char **update_environment(void)
     uint64_t total_envvar = 0;
 
     int ld_debug_exists = 0;
-    while (environ[total_envvar] != '\0')
+    while (*environ[total_envvar] != '\0')
     {
         // If LD_DEBUG or LD_DEBUG_OUTPUT are already set, we need to give
         // up, because we don't want to overwrite the user's desired


### PR DESCRIPTION
This patch fixes a weird behaviour during the execution of the workaround for the AMD fam10h processors. Erratum 420 tells that to disable IBS support two writes are required. The first just clears the IBS_OP_MAX_CNT while the second clear the whole IBS_OP_CTL.
Within the two writes provided by the workaround an interrupt may occur, but the driver could not understand it is intended for ibs and leaves it unhandled. This would result in an unknown NMI. Mostly this is not a problem, but in some systems, there may be some mechanism such as the NMI watchdog which catches the interrupt and does operations (even system reboot) thinking it is due to an unexpected hardware behaviour.
To tackle such a problem, we set the IBS_OP_VAL bit so that, if an interrupt is generated because of the first write the driver can catch it. The driver gets this is a workaround side effect when looking at the IBS_OP_CTL and sees the IBS_OP_VAL bit set and the IBS_OP_MAX_CNT(_OLD) is equal to 0. In that case, the driver informs the system the interrupt has been handled, but it doesn't restart the ibs logic. The last write resets the IBS_OP_CTL.

This patch fixes two minor issues too.
