### PR TITLE
fix the pre-emption bug and add tested EPYC CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ In addition, it has been tested on the following processors, though its logic sh
     - Family 15h Model 60h (CPU formerly code-named "Excavator")
 * AMD Ryzen&trade; 7 1800X
     - Family 17h Model 01h (CPU formerly code-named "Zen")
-
+* AMD EPYC&trade; 7301
+    - Family 17h Model 01h (CPU formerly code-named "Zen")
 Using the AMD Research IBS Toolkit
 --------------------------------------------------------------------------------
 The AMD Research IBS Toolkit includes most of the tools necessary to analyze applications using IBS. This includes the driver to access IBS, a monitoring application which automatically gathers IBS samples from an application under test, an application to decode these IBS samples into a human-readable format, and a tool to annotate these samples with application-level information about each instruction.


### PR DESCRIPTION
The driver code was incorrectly calling the setup_APIC_eilvt() function without first disabling the pre-emption. (see https://elixir.bootlin.com/linux/v4.6.4/source/arch/x86/kernel/apic/apic.c#L422) 
That was occasionally causing kernel panic when loading the ibs.ko module. 
Additionally, added EPYC 7301 as a tested CPU. 